### PR TITLE
.show() deprecated/removed in CircuitPython 10.0.3

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -278,11 +278,11 @@ class Menu:
 
     def show(self):
         """Show this menu on the display."""
-        self.display.show(self.display_group)
+        self.display.root_group = self.display_group
 
     def hide(self):
         """Show CircuitPython REPL again."""
-        self.display.show(None)  # type: ignore[arg-type]
+        self.display.root_group = None  # type: ignore[arg-type]
 
     def serialize(self) -> dict[str, Any]:
         """Get a dict of all item values in this menu.


### PR DESCRIPTION
Thank you very much for your work!

I'm currently trying this out with CircuitPython 10.0.3 and stumbled across an outdated function: .show()

[menu.py row 281](https://github.com/zerario/CircuitPython-Menu/blob/b2bbb4adcfcf747611897e53682b970d81ece6ec/menu.py#L281C9-L281C46)
[menu.py row 285](https://github.com/zerario/CircuitPython-Menu/blob/b2bbb4adcfcf747611897e53682b970d81ece6ec/menu.py#L285C1-L285C58)

This has been removed from CircuitPython: [https://github.com/adafruit/circuitpython/pull/8456](https://github.com/adafruit/circuitpython/pull/8456)
